### PR TITLE
Add `systemd` to hook targets

### DIFF
--- a/kernel-update.hook
+++ b/kernel-update.hook
@@ -4,6 +4,7 @@ Operation = Upgrade
 Operation = Install
 Target = linux*
 Target = intel-ucode
+Target = systemd
 
 [Action]
 Description = Updating EFI kernel images


### PR DESCRIPTION
See #7.

When `systemd` is upgraded but e.g. `linux` isn't, the image will be rebuilt but the hook will not be triggered. Targets should include all packages that might trigger a Kernel image build.