### PR TITLE
Honor rebuilding initramfs in pacman hook

### DIFF
--- a/kernel-update.hook
+++ b/kernel-update.hook
@@ -1,9 +1,10 @@
 [Trigger]
-Type = Package
+Type = Path
 Operation = Upgrade
 Operation = Install
-Target = linux*
-Target = intel-ucode
+Target = usr/lib/modules/*/vmlinuz
+Target = usr/lib/initcpio/*
+Target = boot/intel-ucode.img
 
 [Action]
 Description = Updating EFI kernel images


### PR DESCRIPTION
Changes are done similarly to /usr/share/libalpm/hooks/90-mkinitcpio-install.hook